### PR TITLE
Feat : basic setup for custom monitoring service . 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+.vscode/launch.json
+.vscode/settings.json
+
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc
+clipboard_history.txt

--- a/ClipboardMonitor/.gitignore
+++ b/ClipboardMonitor/.gitignore
@@ -1,0 +1,10 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc
+clipboard_history.txt
+/.vscode

--- a/ClipboardMonitor/Package.swift
+++ b/ClipboardMonitor/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "ClipboardMonitor",
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .executableTarget(
+            name: "ClipboardMonitor"),
+    ]
+)

--- a/ClipboardMonitor/Sources/HistoryManager.swift
+++ b/ClipboardMonitor/Sources/HistoryManager.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+public class HistoryManager {
+    
+    private var filePath: String
+    init(filePath: String){
+        self.filePath = filePath
+    }
+
+    func saveToClipboardHistory(_ content: String) {
+        let fileURL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(filePath)
+        let entry = "\(Date()): \(content)\n"
+        do {
+            if FileManager.default.fileExists(atPath: fileURL.path) {
+                let fileHandle = try FileHandle(forWritingTo: fileURL)
+                fileHandle.seekToEndOfFile()
+                if let data = entry.data(using: .utf8) {
+                    fileHandle.write(data)
+                }
+                fileHandle.closeFile()
+            } else {
+                try entry.write(to: fileURL, atomically: true, encoding: .utf8)
+            }
+        } catch {
+            print("Failed to save clipboard content: \(error)")
+        }
+    }
+}

--- a/ClipboardMonitor/Sources/Monitor.swift
+++ b/ClipboardMonitor/Sources/Monitor.swift
@@ -1,0 +1,31 @@
+import Cocoa
+import Combine
+
+@available(macOS 10.15, *)
+public class Monitor {
+    private let pasteboard = NSPasteboard.general
+    private var lastChangeCount: Int
+
+    let clipboardPublisher = PassthroughSubject<String, Never>()
+
+    init() {
+        self.lastChangeCount = pasteboard.changeCount
+        startMonitoring()
+    }
+
+     private func startMonitoring() {
+        Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+            self.checkForChanges()
+        }
+    }
+
+    private func checkForChanges() {
+        let currentChangeCount = pasteboard.changeCount
+        if currentChangeCount != lastChangeCount {
+            lastChangeCount = currentChangeCount
+            if let clipboardContent = pasteboard.string(forType: .string) {
+                clipboardPublisher.send(clipboardContent)
+            }
+        }
+    }
+}

--- a/ClipboardMonitor/Sources/main.swift
+++ b/ClipboardMonitor/Sources/main.swift
@@ -1,0 +1,23 @@
+import Combine
+import Foundation
+
+@available(macOS 10.15, *)
+struct Main {
+    static func run() {
+        var cancellables: Set<AnyCancellable> = []
+        let monitor = Monitor()
+        let historyManager = HistoryManager(filePath: "YouCanCallMeX/macos-clipboard/clipboard_history.txt")
+
+        monitor.clipboardPublisher.sink { clipboardContent in
+            historyManager.saveToClipboardHistory(clipboardContent)
+        }.store(in: &cancellables)
+        RunLoop.current.run()
+    }
+}
+
+// Ensure the Main struct is only used on macOS 10.15 or newer
+if #available(macOS 10.15, *) {
+    Main.run()
+} else {
+    print("This version of macOS does not support the monitor features.")
+}

--- a/ClipboardMonitor/dockerfile
+++ b/ClipboardMonitor/dockerfile
@@ -1,0 +1,17 @@
+# Use the official Swift image as a parent image
+FROM swift:5.9
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the current directory contents into the container at /app
+COPY . .
+
+# Resolve Swift package dependencies
+RUN swift package resolve
+
+# Build the application
+RUN swift build -c release
+
+# Run the application
+CMD [".build/release/ClipboardMonitor"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.8"
+services:
+  rabbitmq:
+    image: "rabbitmq:3-management"
+    hostname: "rabbitmq"
+    environment:
+      RABBITMQ_DEFAULT_USER: "user"
+      RABBITMQ_DEFAULT_PASS: "password"
+    ports:
+      - "5672:5672" # AMQP protocol
+      - "15672:15672" # Management interface
+
+  clipboardmonitor:
+    build: .
+    depends_on:
+      - rabbitmq
+    environment:
+      RABBITMQ_HOST: "rabbitmq"
+      RABBITMQ_USER: "user"
+      RABBITMQ_PASSWORD: "password"


### PR DESCRIPTION
Here is the basic setup for custom monitoring service. 
- Following the pattern of separation of concerns, where monitoring service will poll every second to check the changes in the `PasteBoard` of Apple applications . 
- Whenever there is a change, the values will be pushed to a message queue (using `RabbitMQ`). 
- `ClipboardMonitor` service will act as a producer.